### PR TITLE
Update SubjectAlternative ValidatePattern regex to allow mulitple comma delimited names (in a single string)

### DIFF
--- a/OpenSSL.psm1
+++ b/OpenSSL.psm1
@@ -1206,7 +1206,7 @@ Function New-SelfSignedCertificate {
 
     [Parameter(Mandatory=$false, HelpMessage="Subject alternative name fields (e.g. IP:10.1.1.1, DNS:server.net)", ParameterSetName="General")]
     [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+$', Options='None')]
+    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+(?:,(IP|DNS|URI|RID|otherName|email):[^,]+)*$', Options='None')]
     [String[]]
     $SubjectAlternative,
 
@@ -1747,7 +1747,7 @@ Function New-CertificateRequest {
 
     [Parameter(Mandatory=$false, HelpMessage="Subject alternative name fields (e.g. IP:10.1.1.1, DNS:server.net)", ParameterSetName="General")]
     [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+$', Options='None')]
+    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+(?:,(IP|DNS|URI|RID|otherName|email):[^,]+)*$', Options='None')]
     [String[]]
     $SubjectAlternative,
 
@@ -2285,7 +2285,7 @@ Function Invoke-SignCertificateRequest {
 
     [Parameter(Mandatory=$false, HelpMessage="Subject alternative name fields (e.g. IP:10.1.1.1, DNS:server.net)", ParameterSetName="General")]
     [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+$', Options='None')]
+    [ValidatePattern('^(IP|DNS|URI|RID|otherName|email):[^,]+(?:,(IP|DNS|URI|RID|otherName|email):[^,]+)*$', Options='None')]
     [String[]]
     $SubjectAlternative,
 


### PR DESCRIPTION
Hello,
I found that when I was using the SubjectAlternative parameter I was unable to append multiple names.
Error:
Invoke-SignCertificateRequest : Cannot validate argument on parameter 'SubjectAlternative'. The argument "DNS:develop.XXX DNS:api.develop.XXX"
does not match the "^(IP|DNS|URI|RID|otherName|email):[^,]+$" pattern. Supply an argument that matches "^(IP|DNS|URI|RID|otherName|email):[^,]+$" and try the command again.

Close inspection reveals the ValidatePattern regex fails to match correctly when multiple names are appended.

I have updated and tested a new regex that allow for multiple comma delimited names - which I believe is what was originally intended.